### PR TITLE
[AND-498] Removing changelog duplication in README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ sample/local.properties
 sample/sample.iml
 **/bin
 **/gen
+
+sample/.idea/

--- a/README.md
+++ b/README.md
@@ -10,22 +10,6 @@ Once you've created an account you can follow our [Getting Started for Andriod G
 * If your application is written in C/C++, you'll need to use JNI to interface with the Publisher SDK written in Java
 * Java 1.7 - For Android 5.+ compatibility purposes, JDK 7 is required on the development system 
 
-## Release Notes
-### 3.3.5
-* Added support for Dagger 2
-* Increased minimum supported Android SDK level from API 9 to API 11
-* Upgraded maximum Google Play Services version to 8.3.0
-* Removed dependencies on support-v4 library and nineoldandroids library
-* Fixed black screen issue with Unity plugin
-
-### 3.3.4
-* Fixed a bug that might cause a crash on devices with Android 4.2 or lower OS
-* Fixed a bug to resume the video ad upon unlocking the screen on devices with screenlock set to none
-* Persist sleeps across app restarts
-
-### 3.3.3
-* Added support for Android Marshmallow by simplifying the required app permissions
-
 
 ## License
 The Vungle Android-SDK is available under a commercial license. See the LICENSE file for more info.


### PR DESCRIPTION
Going ahead we wouldn’t be packaging README into the release artifact
zip file. The changelog information is accessible for Vungle Dashboard.