### PR TITLE
[AND-910] Proguard config necessary for 4.1.0 build

### DIFF
--- a/sample/proguard-project.txt
+++ b/sample/proguard-project.txt
@@ -16,6 +16,7 @@
 #   public *;
 #}
 -dontwarn com.vungle.**
+-dontnote com.vungle.**
 -keep class com.vungle.** { *; }
 -keep class javax.inject.*
 # ignore eventbus warnings
@@ -33,3 +34,7 @@
 -keepclassmembers class rx.internal.util.unsafe.BaseLinkedQueueConsumerNodeRef {
     rx.internal.util.atomic.LinkedQueueNode consumerNode;
 }
+-keep class rx.schedulers.Schedulers { public static <methods>; }
+-keep class rx.schedulers.ImmediateScheduler { public <methods>; }
+-keep class rx.schedulers.TestScheduler { public <methods>; }
+-keep class rx.schedulers.Schedulers { public static ** test(); }

--- a/sample/proguard-project.txt
+++ b/sample/proguard-project.txt
@@ -18,3 +18,18 @@
 -dontwarn com.vungle.**
 -keep class com.vungle.** { *; }
 -keep class javax.inject.*
+# ignore eventbus warnings
+-dontwarn de.greenrobot.event.util.**
+# ignore rx warnings
+-dontwarn rx.internal.util.unsafe.**
+# keep some important rx stuff - https://github.com/ReactiveX/RxJava/issues/3097
+-keepclassmembers class rx.internal.util.unsafe.*ArrayQueue*Field* {
+    long producerIndex;
+    long consumerIndex;
+}
+-keepclassmembers class rx.internal.util.unsafe.BaseLinkedQueueProducerNodeRef {
+    rx.internal.util.atomic.LinkedQueueNode producerNode;
+}
+-keepclassmembers class rx.internal.util.unsafe.BaseLinkedQueueConsumerNodeRef {
+    rx.internal.util.atomic.LinkedQueueNode consumerNode;
+}


### PR DESCRIPTION
Since EventBus and Rx jar files are packaged separately outside the SDK, publishers need some additional proguard settings to make sure those jar files are properly proguarded.

@annavungle I have verified these settings. Feel free to do more extensive testing before communicating the same to pubs. Use gradle task `installRelease` to verify.